### PR TITLE
Stop looking for repository directory when we find a .git dir

### DIFF
--- a/cpplint/dunecpplint.py
+++ b/cpplint/dunecpplint.py
@@ -1160,6 +1160,7 @@ class FileInfo(object):
             os.path.exists(os.path.join(current_dir, ".hg")) or
             os.path.exists(os.path.join(current_dir, ".svn"))):
           root_dir = current_dir
+          break
         current_dir = os.path.dirname(current_dir)
 
       if (os.path.exists(os.path.join(root_dir, ".git")) or


### PR DESCRIPTION
Found this bug by having a directory tree like
```
dune-daq-base/
-- dev-v2.10.0/
    -- sourcecode/
        -- dfmodules/
            -- .git/
-- .git/
```
dunecpplint.py would assume that dune-daq-base was the "repository dir" for basing header include guards off of, instead of dfmodules.